### PR TITLE
minor refactor for performance

### DIFF
--- a/skimage/morphology/_flood_fill.py
+++ b/skimage/morphology/_flood_fill.py
@@ -7,6 +7,7 @@ connected to a given seed point with a different value.
 import numpy as np
 
 from .._shared.utils import deprecate_kwarg
+from ..util import crop
 from ._flood_fill_cy import _flood_fill_equal, _flood_fill_tolerance
 from ._util import (_offsets_to_raveled_neighbors, _resolve_neighborhood,
                     _set_border_values,)
@@ -232,27 +233,29 @@ def flood(image, seed_point, *, footprint=None, connectivity=None,
 
     footprint = _resolve_neighborhood(
         footprint, connectivity, image.ndim, enforce_adjacency=False)
-    center = np.array(footprint.shape) // 2
-
-    # Compute pad count as the maximum offset to neighbors across all axes.
-    neighbor_indices = np.array(np.nonzero(footprint)).T
-    neighbor_coordinate_offsets = np.ravel(neighbor_indices - center)
-    pad_count = np.max(np.abs(neighbor_coordinate_offsets))
+    center = tuple(s // 2 for s in footprint.shape)
+    # Compute padding width as the maximum offset to neighbors on each axis.
+    # Generates a 2-tuple of (pad_start, pad_end) for each axis.
+    pad_width = [(np.max(np.abs(idx - c)),) * 2
+                 for idx, c in zip(np.nonzero(footprint), center)]
 
     # Must annotate borders
-    working_image = np.pad(image, pad_count, mode='constant',
+    working_image = np.pad(image, pad_width, mode='constant',
                            constant_values=image.min())
-
     # Stride-aware neighbors - works for both C- and Fortran-contiguity
     ravelled_seed_idx = np.ravel_multi_index(
-        [i + pad_count for i in seed_point], working_image.shape, order=order)
+        [i + pad_start
+         for i, (pad_start, pad_end) in zip(seed_point, pad_width)],
+        working_image.shape,
+        order=order
+    )
     neighbor_offsets = _offsets_to_raveled_neighbors(
         working_image.shape, footprint, center=center,
         order=order)
 
     # Use a set of flags; see _flood_fill_cy.pyx for meanings
-    flags = np.zeros(image.shape, dtype=np.uint8, order=order)
-    flags = np.pad(flags, pad_count, constant_values=2)
+    flags = np.zeros(working_image.shape, dtype=np.uint8, order=order)
+    _set_border_values(flags, value=2, border_width=pad_width)
 
     try:
         if tolerance is not None:
@@ -289,4 +292,4 @@ def flood(image, seed_point, *, footprint=None, connectivity=None,
             raise
 
     # Output what the user requested; view does not create a new copy.
-    return flags[(slice(pad_count, -pad_count),) * image.ndim].view(bool)
+    return crop(flags, pad_width, copy=False).view(bool)

--- a/skimage/morphology/_util.py
+++ b/skimage/morphology/_util.py
@@ -121,15 +121,16 @@ def _raveled_offsets_and_distances(
                 rank=ndim, connectivity=connectivity
                 )
     if center is None:
-        center = np.array(footprint.shape) // 2
+        center = tuple(s // 2 for s in footprint.shape)
+
     if not footprint.ndim == ndim == len(center):
         raise ValueError(
-                "number of dimensions in image shape, footprint and its"
-                "center index does not match"
-                )
+            "number of dimensions in image shape, footprint and its"
+            "center index does not match")
 
-    footprint_indices = np.stack(np.nonzero(footprint), axis=-1)
-    offsets = footprint_indices - center
+    offsets = np.stack([(idx - c)
+                        for idx, c in zip(np.nonzero(footprint), center)],
+                       axis=-1)
 
     if order == 'F':
         offsets = offsets[:, ::-1]
@@ -268,7 +269,7 @@ def _resolve_neighborhood(footprint, connectivity, ndim,
     return footprint
 
 
-def _set_border_values(image, value):
+def _set_border_values(image, value, border_width=1):
     """Set edge values along all axes to a constant value.
 
     Parameters
@@ -277,6 +278,11 @@ def _set_border_values(image, value):
         The array to modify inplace.
     value : scalar
         The value to use. Should be compatible with `image`'s dtype.
+    border_width : int or sequence of tuples
+        A sequence with one 2-tuple per axis where the first and second values
+        are the width of the border at the start and end of the axis,
+        respectively. If an int is provided, a uniform border width along all
+        axes is used.
 
     Examples
     --------
@@ -287,8 +293,39 @@ def _set_border_values(image, value):
            [1, 0, 0, 0, 1],
            [1, 0, 0, 0, 1],
            [1, 1, 1, 1, 1]])
+    >>> image = np.zeros((8, 8), dtype=int)
+    >>> _set_border_values(image, 1, border_width=((1, 1), (2, 3)))
+    >>> image
+    array([[1, 1, 1, 1, 1, 1, 1, 1],
+           [1, 1, 0, 0, 0, 1, 1, 1],
+           [1, 1, 0, 0, 0, 1, 1, 1],
+           [1, 1, 0, 0, 0, 1, 1, 1],
+           [1, 1, 0, 0, 0, 1, 1, 1],
+           [1, 1, 0, 0, 0, 1, 1, 1],
+           [1, 1, 0, 0, 0, 1, 1, 1],
+           [1, 1, 1, 1, 1, 1, 1, 1]])
     """
-    for axis in range(image.ndim):
-        # Index first and last element in each dimension
-        sl = (slice(None),) * axis + ((0, -1),) + (...,)
-        image[sl] = value
+    if np.isscalar(border_width):
+        border_width = ((border_width, border_width),) * image.ndim
+    elif len(border_width) != image.ndim:
+        raise ValueError('length of `border_width` must match image.ndim')
+    for axis, npad in enumerate(border_width):
+        if len(npad) != 2:
+            raise ValueError('each sequence in `border_width` must have '
+                             'length 2')
+        w_start, w_end = npad
+        if w_start == w_end == 0:
+            continue
+        elif w_start == w_end == 1:
+            # Index first and last element in the current dimension
+            sl = (slice(None),) * axis + ((0, -1),) + (...,)
+            image[sl] = value
+            continue
+        if w_start > 0:
+            # set first w_start entries along axis to value
+            sl = (slice(None),) * axis + (slice(0, w_start),) + (...,)
+            image[sl] = value
+        if w_end > 0:
+            # set last w_end entries along axis to value
+            sl = (slice(None),) * axis + (slice(-w_end, None),) + (...,)
+            image[sl] = value


### PR DESCRIPTION
## Description

This PR suggests changes that restore the use of `_set_border_values` (updating it to work for arbitrary pad_width). This allows avoids extra array copies.

One other subtle difference is that the amount of padding is computed on a per-axis basis instead of globally over the footprint. I suspect in most (all?) practical cases the footprint is symmetric, so that aspect is probably fairly unimportant.

This is purely a performance-based refactor and should result in no change to the behavior of your proposed feature.

## Checklist

<!-- It's fine to submit PRs which are a work in progress! -->
<!-- But before they are merged, all PRs should provide: -->
- [Docstrings for all functions](https://github.com/numpy/numpy/blob/master/doc/example.py)
- Gallery example in `./doc/examples` (new features only)
- Benchmark in `./benchmarks`, if your changes aren't covered by an
  existing benchmark
- Unit tests
- Clean style in [the spirit of PEP8](https://www.python.org/dev/peps/pep-0008/)
- Descriptive commit messages (see below)

<!-- For detailed information on these and other aspects see -->
<!-- the scikit-image contribution guidelines. -->
<!-- https://scikit-image.org/docs/dev/contribute.html -->

## For reviewers

<!-- Don't remove the checklist below. -->
- Check that the PR title is short, concise, and will make sense 1 year
  later.
- Check that new functions are imported in corresponding `__init__.py`.
- Check that new features, API changes, and deprecations are mentioned in
      `doc/release/release_dev.rst`.
